### PR TITLE
feat: add interactive to-do list assignment

### DIFF
--- a/.github/workflows/fs-02-interactive.yml
+++ b/.github/workflows/fs-02-interactive.yml
@@ -1,0 +1,28 @@
+name: fs-02-interactive CI
+
+on:
+  push:
+    paths:
+      - 'assignments-fullstack/fs-02-interactive/**'
+      - '.github/workflows/fs-02-interactive.yml'
+  pull_request:
+    paths:
+      - 'assignments-fullstack/fs-02-interactive/**'
+      - '.github/workflows/fs-02-interactive.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: assignments-fullstack/fs-02-interactive
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+      - run: npm run lint
+      - run: npm audit --audit-level=high
+      - run: npm run test:performance

--- a/assignments-fullstack/fs-02-interactive/README.md
+++ b/assignments-fullstack/fs-02-interactive/README.md
@@ -1,0 +1,20 @@
+# Assignment FS-02 — Interactive
+
+Crea una lista de tareas accesible con interacción de teclado.
+
+## Requisitos
+- Las tareas se pueden agregar con clic o presionando `Enter` en el campo de texto.
+- Cada ítem utiliza roles ARIA adecuados (`list`/`listitem`).
+- Las casillas pueden alternarse con `Space` o `Enter`.
+- No rompas las pruebas automáticas.
+
+## Cómo correr
+```bash
+npm ci
+npm test
+npm run lint
+npm run test:performance
+```
+
+## Entrega
+Sube tu solución vía **GitHub Classroom**.

--- a/assignments-fullstack/fs-02-interactive/eslint.config.js
+++ b/assignments-fullstack/fs-02-interactive/eslint.config.js
@@ -1,0 +1,20 @@
+export default [
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      globals: {
+        document: 'readonly',
+        window: 'readonly',
+        URL: 'readonly',
+        process: 'readonly',
+        console: 'readonly'
+      }
+    },
+    rules: {
+      'no-unused-vars': ['error', { args: 'none' }],
+      'no-undef': 'error'
+    }
+  }
+];

--- a/assignments-fullstack/fs-02-interactive/package.json
+++ b/assignments-fullstack/fs-02-interactive/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "fs-02-interactive",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node --test test/app.test.js",
+    "test:performance": "node --test test/performance.test.js",
+    "lint": "eslint src test"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "jsdom": "^24.0.0"
+  }
+}

--- a/assignments-fullstack/fs-02-interactive/src/app.js
+++ b/assignments-fullstack/fs-02-interactive/src/app.js
@@ -1,0 +1,45 @@
+export function init(document) {
+  const input = document.getElementById('new-todo');
+  const list = document.getElementById('todo-list');
+  const addButton = document.getElementById('add-todo');
+
+  function addTodo(text) {
+    const li = document.createElement('li');
+    li.setAttribute('role', 'listitem');
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.setAttribute('aria-label', 'Marcar completado');
+    checkbox.addEventListener('keydown', (event) => {
+      if (event.key === ' ' || event.key === 'Enter') {
+        checkbox.checked = !checkbox.checked;
+        event.preventDefault();
+      }
+    });
+
+    li.appendChild(checkbox);
+    li.appendChild(document.createTextNode(text));
+    list.appendChild(li);
+  }
+
+  addButton.addEventListener('click', () => {
+    const text = input.value.trim();
+    if (text) {
+      addTodo(text);
+      input.value = '';
+      input.focus();
+    }
+  });
+
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      addButton.click();
+    }
+  });
+
+  return { addTodo, list, input };
+}
+
+if (typeof document !== 'undefined') {
+  init(document);
+}

--- a/assignments-fullstack/fs-02-interactive/src/index.html
+++ b/assignments-fullstack/fs-02-interactive/src/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Lista de tareas</title>
+  </head>
+  <body>
+    <h1>Lista de tareas</h1>
+    <input id="new-todo" aria-label="Nueva tarea" />
+    <button id="add-todo">Agregar</button>
+    <ul id="todo-list" role="list"></ul>
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/assignments-fullstack/fs-02-interactive/src/server.js
+++ b/assignments-fullstack/fs-02-interactive/src/server.js
@@ -1,0 +1,13 @@
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+
+const server = createServer(async (req, res) => {
+  const html = await readFile(new URL('./index.html', import.meta.url));
+  res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+  res.end(html);
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Servidor escuchando en http://localhost:${PORT}`);
+});

--- a/assignments-fullstack/fs-02-interactive/test/app.test.js
+++ b/assignments-fullstack/fs-02-interactive/test/app.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import fs from 'node:fs';
+import { init } from '../src/app.js';
+
+function setupDom() {
+  const html = fs.readFileSync(new URL('../src/index.html', import.meta.url), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'outside-only' });
+  const api = init(dom.window.document);
+  return { dom, ...api };
+}
+
+test('agregar tarea con clic', () => {
+  const { dom } = setupDom();
+  const input = dom.window.document.getElementById('new-todo');
+  const button = dom.window.document.getElementById('add-todo');
+  input.value = 'Estudiar';
+  button.click();
+  assert.equal(dom.window.document.querySelectorAll('#todo-list li').length, 1);
+});
+
+test('roles ARIA correctos', () => {
+  const { addTodo, list } = setupDom();
+  addTodo('Leer');
+  assert.equal(list.getAttribute('role'), 'list');
+  const item = list.querySelector('li');
+  assert.equal(item.getAttribute('role'), 'listitem');
+});
+
+test('Enter en input agrega tarea', () => {
+  const { dom, list } = setupDom();
+  const input = dom.window.document.getElementById('new-todo');
+  input.value = 'Dormir';
+  input.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+  assert.equal(list.children.length, 1);
+});
+
+test('Espacio o Enter alterna checkbox', () => {
+  const { dom, addTodo, list } = setupDom();
+  addTodo('Correr');
+  const checkbox = list.querySelector('input[type="checkbox"]');
+  checkbox.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+  assert.equal(checkbox.checked, true);
+  checkbox.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+  assert.equal(checkbox.checked, false);
+});

--- a/assignments-fullstack/fs-02-interactive/test/performance.test.js
+++ b/assignments-fullstack/fs-02-interactive/test/performance.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import fs from 'node:fs';
+import { performance } from 'node:perf_hooks';
+import { init } from '../src/app.js';
+
+function setupDom() {
+  const html = fs.readFileSync(new URL('../src/index.html', import.meta.url), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'outside-only' });
+  const api = init(dom.window.document);
+  return { dom, ...api };
+}
+
+test('addTodo 1000 items < 50ms', () => {
+  const { addTodo } = setupDom();
+  const start = performance.now();
+  for (let i = 0; i < 1000; i++) {
+    addTodo(`tarea ${i}`);
+  }
+  const duration = performance.now() - start;
+  assert.ok(duration < 50, `tardó ${duration}ms`);
+});


### PR DESCRIPTION
## Summary
- add accessible to-do list example for FS-02 assignment
- validate interactions with tests and performance check
- add workflow running test, lint, audit and performance

## Testing
- `npm test` *(fails: Cannot find package 'jsdom')*
- `npm run lint`
- `npm audit --audit-level=high` *(fails: requires an existing lockfile)*
- `npm run test:performance` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68c37500177483258dbd7bb81c7aaac8