### PR TITLE
docs: agregar módulo DOM y actualizar navegación

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,5 +11,7 @@ nav_external_links:
     url: /public/
   - title: Módulo 01
     url: /modulos/01-html-basico.html
+  - title: Módulo 02
+    url: /modulos/02-dom.html
   - title: Roadmap
     url: /modulos/00-scratch.html

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,4 +6,4 @@ nav_order: 0
 
 Bienvenid@. Abajo tenés el recorrido para crear y **deployar tu primera página web**.
 
-**Accesos rápidos:** [Mi primera web](public/) · [Módulo 01](modulos/01-html-basico.html) · [Roadmap](modulos/00-scratch.html)
+**Accesos rápidos:** [Mi primera web](public/) · [Módulo 01](modulos/01-html-basico.html) · [Módulo 02](modulos/02-dom.html) · [Roadmap](modulos/00-scratch.html)

--- a/docs/modulos/02-dom.md
+++ b/docs/modulos/02-dom.md
@@ -1,0 +1,24 @@
+---
+title: 02 — DOM, eventos, accesibilidad y errores
+nav_order: 3
+---
+# 02 — DOM, eventos, accesibilidad y manejo de errores
+
+## DOM
+- El **Document Object Model** representa la página como un árbol de nodos.
+- Permite leer y modificar elementos con JavaScript (`document.querySelector`, `element.textContent`, etc.).
+
+## Eventos
+- Responden a interacciones como `click`, `input` o `submit`.
+- Se registran con `addEventListener` y pueden cancelarse con `preventDefault`.
+- Delegar eventos en contenedores mejora rendimiento y limpieza de código.
+
+## Accesibilidad
+- Usa etiquetas semánticas (`<header>`, `<nav>`, `<button>`) para ayudar a lectores de pantalla.
+- Asegura contraste de colores y soporte de teclado (`tabindex`, `aria-label`).
+- Prueba con herramientas como **Lighthouse** o **axe**.
+
+## Manejo de errores
+- Envuelve código riesgoso con `try/catch`.
+- Emite mensajes claros para el usuario y registra detalles técnicos (console o servicios externos).
+- Usa `window.onerror` o `unhandledrejection` para capturar errores globales.


### PR DESCRIPTION
## Summary
- Añade módulo sobre DOM, eventos, accesibilidad y manejo de errores.
- Agrega el módulo 02 a la navegación y a los accesos rápidos.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c37500ead083259a4fa116cffb5767