### PR TITLE
Add FS-01 HTML/CSS/JS quiz with score persistence

### DIFF
--- a/docs/h5p/fs-01-quiz/index.html
+++ b/docs/h5p/fs-01-quiz/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Quiz FS-01 — HTML/CSS/JS</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; max-width: 800px; margin: 32px auto; padding: 0 16px; }
+    .q { border: 1px solid #ddd; border-radius: 12px; padding: 16px; margin: 12px 0; }
+    button { padding: 8px 14px; border-radius: 8px; border: 1px solid #999; background: #f6f6f6; cursor: pointer; }
+    .ok { color: #0a7f2e; } .bad { color: #b00020; }
+  </style>
+</head>
+<body>
+<h1>Quiz FS-01 — HTML/CSS/JS</h1>
+<p>Corre 100% local/offline. No envía datos.</p>
+<div id="quiz"></div>
+<button id="finish">Calificar</button>
+<div id="result" style="margin-top:12px;"></div>
+<noscript>
+  <p>Este quiz necesita JavaScript para calificar automáticamente. Respuestas correctas al final.</p>
+  <ol>
+    <li>
+      <p>¿Qué etiqueta HTML se usa para crear un enlace?</p>
+      <ul>
+        <li>&lt;link&gt;</li>
+        <li>&lt;a&gt;</li>
+        <li>&lt;href&gt;</li>
+        <li>&lt;url&gt;</li>
+      </ul>
+      <p>Respuesta correcta: &lt;a&gt;</p>
+    </li>
+    <li>
+      <p>¿Qué selector CSS selecciona un elemento con id "principal"?</p>
+      <ul>
+        <li>#principal</li>
+        <li>.principal</li>
+        <li>principal</li>
+        <li>*principal</li>
+      </ul>
+      <p>Respuesta correcta: #principal</p>
+    </li>
+    <li>
+      <p>¿Cuál es la sintaxis correcta para declarar una función llamada <code>sumar</code>?</p>
+      <ul>
+        <li><code>function sumar(a,b) { return a+b; }</code></li>
+        <li><code>func sumar(a,b) { return a+b; }</code></li>
+        <li><code>function:sumar(a,b){return a+b;}</code></li>
+        <li><code>def sumar(a,b): return a+b</code></li>
+      </ul>
+      <p>Respuesta correcta: <code>function sumar(a,b) { return a+b; }</code></p>
+    </li>
+  </ol>
+</noscript>
+<script src="script.js"></script>
+</body>
+</html>

--- a/docs/h5p/fs-01-quiz/script.js
+++ b/docs/h5p/fs-01-quiz/script.js
@@ -1,0 +1,53 @@
+const QUESTIONS = [
+  {
+    t: "¿Qué etiqueta HTML se usa para crear un enlace?",
+    a: ["<a>", "<link>", "<href>", "<url>"],
+    c: 0
+  },
+  {
+    t: "¿Qué selector CSS selecciona un elemento con id \"principal\"?",
+    a: ["#principal", ".principal", "principal", "*principal"],
+    c: 0
+  },
+  {
+    t: "¿Cuál es la sintaxis correcta para declarar una función llamada sumar?",
+    a: ["function sumar(a,b) { return a+b; }", "func sumar(a,b) { return a+b; }", "function: sumar(a,b) { return a+b; }", "def sumar(a,b): return a+b"],
+    c: 0
+  }
+];
+
+const quizDiv = document.getElementById("quiz");
+QUESTIONS.forEach((q,i)=>{
+  const d = document.createElement("div");
+  d.className = "q";
+  d.innerHTML = `<p><b>Q${i+1}.</b> ${q.t}</p>` + q.a.map((opt,j)=>{
+    return `<div><label><input type="radio" name="q${i}" value="${j}"> ${opt}</label></div>`;
+  }).join("");
+  quizDiv.appendChild(d);
+});
+
+const SCORE_KEY = "fs01Score";
+try {
+  const prev = localStorage.getItem(SCORE_KEY);
+  if (prev !== null) {
+    document.getElementById("result").innerHTML = `<p>Último puntaje: <b>${prev}%</b></p>`;
+  }
+} catch (e) {
+  /* ignore */
+}
+
+document.getElementById("finish").addEventListener("click", ()=>{
+  let ok = 0;
+  QUESTIONS.forEach((q,i)=>{
+    const sel = document.querySelector(`input[name="q${i}"]:checked`);
+    if (sel && +sel.value === q.c) ok++;
+  });
+  const pct = Math.round(100 * ok / QUESTIONS.length);
+  const cls = pct>=80 ? "ok" : "bad";
+  document.getElementById("result").innerHTML = `<p>Correctas: ${ok}/${QUESTIONS.length}. Score: <b class="${cls}">${pct}%</b></p>`;
+  try {
+    localStorage.setItem(SCORE_KEY, pct);
+  } catch (e) {
+    /* ignore */
+  }
+});


### PR DESCRIPTION
## Summary
- add FS-01 quiz on HTML tags, CSS selectors, and JS syntax
- store last score in localStorage and show noscript fallback

## Testing
- `npm test` (fails: package.json not found)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c37502a8088325b019fd56fe74d11c