### PR TITLE
docs: add full stack onboarding module

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -13,3 +13,5 @@ nav_external_links:
     url: /modulos/01-html-basico.html
   - title: Roadmap
     url: /modulos/00-scratch.html
+  - title: Full Stack
+    url: /fullstack/00-onboarding.html

--- a/docs/fullstack/00-onboarding.md
+++ b/docs/fullstack/00-onboarding.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: "Semana 0 · Onboarding & First Website"
+parent: "Full Stack"
+nav_order: 0
+---
+
+# Semana 0 · Onboarding & First Website
+
+## Tabla de contenidos
+{:toc}
+
+## Objetivos
+- Instalar las herramientas básicas de desarrollo.
+- Comprender el flujo de trabajo con Git y GitHub.
+- Publicar una primera página estática.
+
+## Requisitos
+- Cuenta en GitHub.
+- Git y un editor de código instalados.
+- Conexión a Internet.
+
+## Pasos para tu primer sitio
+1. Clona este repositorio y abre la carpeta `docs/public`.
+2. Crea un archivo `index.html` con un saludo simple.
+3. Ejecuta `git add . && git commit -m "feat: primera web" && git push`.
+4. En GitHub, ve a **Settings → Pages** y activa *Deploy from a branch* con `main` y `/docs`.
+5. Visita la URL que genera GitHub Pages para ver tu sitio.


### PR DESCRIPTION
## Summary
- add Week 0 onboarding guide for Full Stack track
- link Full Stack module in site navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c37506ddb883258a4ef8d47e92d449