### PR TITLE
feat: add first website assignment

### DIFF
--- a/assignments-fullstack/fs-00-first-website/.eslintrc.json
+++ b/assignments-fullstack/fs-00-first-website/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["eslint:recommended"]
+}

--- a/assignments-fullstack/fs-00-first-website/.github/workflows/ci.yml
+++ b/assignments-fullstack/fs-00-first-website/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run lint
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm audit --omit=dev
+
+  performance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo 'TODO: performance check'
+
+  deploy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo 'TODO: deploy check'

--- a/assignments-fullstack/fs-00-first-website/.gitignore
+++ b/assignments-fullstack/fs-00-first-website/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/assignments-fullstack/fs-00-first-website/README.md
+++ b/assignments-fullstack/fs-00-first-website/README.md
@@ -1,0 +1,20 @@
+# FS-00 — First Website
+
+Crea un sitio web estático con **HTML**, **CSS** y **JavaScript**.
+
+## Requisitos
+- `index.html` referencia `style.css` y `script.js`.
+- `script.js` imprime `Hola Devs!` en la consola.
+
+## Scripts
+- `npm run dev` — sirve `src/` para desarrollo.
+- `npm run build` — paso de compilación (placeholder).
+- `npm test` — ejecuta las pruebas automatizadas.
+- `npm run lint` — corre ESLint.
+- `npm audit` — revisa vulnerabilidades.
+
+## Cómo correr
+```bash
+npm install
+npm run dev
+```

--- a/assignments-fullstack/fs-00-first-website/RUBRIC.md
+++ b/assignments-fullstack/fs-00-first-website/RUBRIC.md
@@ -1,0 +1,6 @@
+# Rúbrica
+
+- [ ] Estructura básica de HTML, CSS y JS.
+- [ ] Pruebas automatizadas pasan.
+- [ ] Sin errores de ESLint.
+- [ ] Documentación completa en `README.md` y `docs/`.

--- a/assignments-fullstack/fs-00-first-website/docs/README.md
+++ b/assignments-fullstack/fs-00-first-website/docs/README.md
@@ -1,0 +1,6 @@
+# Instrucciones Detalladas
+
+1. Modifica los archivos en `src/` para personalizar tu sitio.
+2. Ejecuta `npm run dev` para ver los cambios en el navegador.
+3. Corre `npm test` y `npm run lint` antes de enviar tu solución.
+4. Revisa `RUBRIC.md` para conocer los criterios de evaluación.

--- a/assignments-fullstack/fs-00-first-website/eslint.config.js
+++ b/assignments-fullstack/fs-00-first-website/eslint.config.js
@@ -1,0 +1,10 @@
+export default [
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      sourceType: "module",
+      globals: { console: "readonly" }
+    },
+    rules: {}
+  }
+];

--- a/assignments-fullstack/fs-00-first-website/package.json
+++ b/assignments-fullstack/fs-00-first-website/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fs-00-first-website",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "http-server ./src -a localhost -p 3000 -o",
+    "build": "echo 'build step'",
+    "test": "node --test tests",
+    "lint": "eslint .",
+    "audit": "npm audit"
+  },
+  "devDependencies": {
+    "eslint": "^8.56.0",
+    "http-server": "^14.1.1"
+  }
+}

--- a/assignments-fullstack/fs-00-first-website/src/index.html
+++ b/assignments-fullstack/fs-00-first-website/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>First Website</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Hola Devs!</h1>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/assignments-fullstack/fs-00-first-website/src/script.js
+++ b/assignments-fullstack/fs-00-first-website/src/script.js
@@ -1,0 +1,1 @@
+console.log('Hola Devs!');

--- a/assignments-fullstack/fs-00-first-website/src/style.css
+++ b/assignments-fullstack/fs-00-first-website/src/style.css
@@ -1,0 +1,6 @@
+body {
+  font-family: sans-serif;
+  background-color: #f5f5f5;
+  margin: 0;
+  padding: 2rem;
+}

--- a/assignments-fullstack/fs-00-first-website/tests/index.test.js
+++ b/assignments-fullstack/fs-00-first-website/tests/index.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const srcDir = path.resolve(__dirname, '../src');
+
+const html = fs.readFileSync(path.join(srcDir, 'index.html'), 'utf8');
+
+test('HTML links CSS', () => {
+  assert.ok(html.includes('<link rel="stylesheet" href="style.css">'));
+});
+
+test('HTML links JS', () => {
+  assert.ok(html.includes('<script src="script.js"></script>'));
+});
+
+test('CSS file exists', () => {
+  assert.ok(fs.existsSync(path.join(srcDir, 'style.css')));
+});
+
+test('JS file exists', () => {
+  assert.ok(fs.existsSync(path.join(srcDir, 'script.js')));
+});


### PR DESCRIPTION
## Summary
- add FS-00 first website assignment scaffolding
- include basic HTML/CSS/JS template with tests
- configure linting and CI workflow

## Testing
- `npm test`
- `npm run lint`
- `npm audit` *(fails: This command requires an existing lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c37507e0408325b8a6363c7ff4f6e6