### PR TITLE
docs: add frontend basics section

### DIFF
--- a/docs/fullstack/01-frontend.md
+++ b/docs/fullstack/01-frontend.md
@@ -1,0 +1,21 @@
+---
+title: "01 — Frontend"
+layout: default
+nav_order: 1
+parent: Fullstack
+---
+
+# 01 — Frontend
+
+## HTML semántico
+- Etiquetas estructurales: `<header>`, `<nav>`, `<main>`, `<footer>`.
+- Uso de `<section>` y `<article>` para agrupar contenido.
+
+## CSS responsive
+- Media queries `@media` para adaptar estilos a distintos tamaños.
+- Flexbox y Grid para lograr un layout flexible.
+
+## JS básico
+- Manipulación del DOM con `document.querySelector`.
+- Manejo de eventos y funciones simples.
+

--- a/docs/fullstack/index.md
+++ b/docs/fullstack/index.md
@@ -1,0 +1,11 @@
+---
+title: Fullstack
+layout: default
+nav_order: 2
+has_children: true
+---
+
+# Fullstack
+
+Recursos del recorrido fullstack.
+


### PR DESCRIPTION
## Summary
- add Fullstack landing page for documentation
- introduce Frontend basics page with HTML, CSS, and JS sections

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3752790308325ac8a2d72de2bcd6f