### PR TITLE
Add landing page assignment with tests and linting

### DIFF
--- a/assignments-fullstack/fs-01-landing/.eslintrc.json
+++ b/assignments-fullstack/fs-01-landing/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "jest": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/assignments-fullstack/fs-01-landing/.github/workflows/ci.yml
+++ b/assignments-fullstack/fs-01-landing/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: assignments-fullstack/fs-01-landing
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test
+      - run: npm run lint
+      - run: npm audit --audit-level=moderate
+      - run: npm run perf

--- a/assignments-fullstack/fs-01-landing/README.md
+++ b/assignments-fullstack/fs-01-landing/README.md
@@ -1,0 +1,3 @@
+# FS-01: Landing Page
+
+Landing page estática con HTML básico. Incluye meta tags esenciales, viewport responsive y prácticas de accesibilidad. Las pruebas automatizadas validan estos aspectos y una métrica de performance sencilla basada en el tiempo de parseo.

--- a/assignments-fullstack/fs-01-landing/RUBRIC.md
+++ b/assignments-fullstack/fs-01-landing/RUBRIC.md
@@ -1,0 +1,8 @@
+# Rúbrica
+
+| Criterio | Descripción |
+| --- | --- |
+| Meta tags | La página define meta tags básicas incluida `description` |
+| Viewport | Define meta `viewport` para responsive |
+| Accesibilidad | No hay violaciones según `axe` |
+| Performance | Tiempo de parseo (TTI simplificado) menor a 1s |

--- a/assignments-fullstack/fs-01-landing/docs/README.md
+++ b/assignments-fullstack/fs-01-landing/docs/README.md
@@ -1,0 +1,1 @@
+Documentación del proyecto de landing page.

--- a/assignments-fullstack/fs-01-landing/package.json
+++ b/assignments-fullstack/fs-01-landing/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "fs-01-landing",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest",
+    "lint": "eslint src tests",
+    "perf": "node tests/performance.test.js",
+    "audit": "npm audit --audit-level=moderate"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "jest": "^29.7.0",
+    "jest-axe": "^7.0.0",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/assignments-fullstack/fs-01-landing/src/index.html
+++ b/assignments-fullstack/fs-01-landing/src/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="Landing de ejemplo">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Landing</title>
+</head>
+<body>
+  <header>
+    <h1>Bienvenido</h1>
+  </header>
+  <main>
+    <p>Página estática de ejemplo.</p>
+    <button type="button">Acción</button>
+  </main>
+</body>
+</html>

--- a/assignments-fullstack/fs-01-landing/tests/meta.test.js
+++ b/assignments-fullstack/fs-01-landing/tests/meta.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+const { axe, toHaveNoViolations } = require('jest-axe');
+
+expect.extend(toHaveNoViolations);
+
+const html = fs.readFileSync(path.join(__dirname, '../src/index.html'), 'utf8');
+const dom = new JSDOM(html);
+
+it('incluye meta tags básicos', () => {
+  const { document } = dom.window;
+  expect(document.querySelector('meta[charset="UTF-8"]')).not.toBeNull();
+  expect(document.querySelector('meta[name="description"]')).not.toBeNull();
+});
+
+it('define viewport responsive', () => {
+  const { document } = dom.window;
+  const viewport = document.querySelector('meta[name="viewport"]');
+  expect(viewport).not.toBeNull();
+  expect(viewport.getAttribute('content')).toMatch(/width=device-width/);
+});
+
+it('no tiene violaciones de accesibilidad', async () => {
+  const results = await axe(dom.window.document);
+  expect(results).toHaveNoViolations();
+});

--- a/assignments-fullstack/fs-01-landing/tests/performance.test.js
+++ b/assignments-fullstack/fs-01-landing/tests/performance.test.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+const { performance } = require('perf_hooks');
+
+test('TTI simplificado menor a 1s', () => {
+  const start = performance.now();
+  const html = fs.readFileSync(path.join(__dirname, '../src/index.html'), 'utf8');
+  new JSDOM(html);
+  const tti = performance.now() - start;
+  expect(tti).toBeLessThan(1000);
+});


### PR DESCRIPTION
## Summary
- add FS-01 landing assignment with meta tag, viewport, accessibility tests
- configure eslint, workflow, and simplified performance check

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config not found)*
- `npm audit --audit-level=moderate` *(fails: requires lockfile)*
- `npm run perf` *(fails: jsdom module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c375049d888325abecac54ad6add8a