### PR TITLE
Add FS-00 quiz with accessible fallback and localStorage

### DIFF
--- a/docs/h5p/fs-00-quiz/index.html
+++ b/docs/h5p/fs-00-quiz/index.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Quiz FS-00</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; max-width: 720px; margin: 32px auto; padding: 0 16px; }
+    fieldset { margin: 16px 0; }
+    button { padding: 8px 14px; border-radius: 8px; border: 1px solid #999; background: #f6f6f6; cursor: pointer; }
+    .ok { color: #0a7f2e; } .bad { color: #b00020; }
+  </style>
+</head>
+<body>
+<h1>Quiz FS-00</h1>
+<form id="quiz">
+  <fieldset aria-describedby="q1-desc">
+    <legend>Pregunta 1</legend>
+    <p id="q1-desc">¿Qué etiqueta HTML se usa para crear un enlace?</p>
+    <div><input type="radio" id="q1a0" name="q1" value="0"><label for="q1a0">&lt;link&gt;</label></div>
+    <div><input type="radio" id="q1a1" name="q1" value="1"><label for="q1a1">&lt;a&gt;</label></div>
+    <div><input type="radio" id="q1a2" name="q1" value="2"><label for="q1a2">&lt;href&gt;</label></div>
+    <div><input type="radio" id="q1a3" name="q1" value="3"><label for="q1a3">&lt;url&gt;</label></div>
+  </fieldset>
+  <fieldset aria-describedby="q2-desc">
+    <legend>Pregunta 2</legend>
+    <p id="q2-desc">¿Qué comando Git envía commits al repositorio remoto?</p>
+    <div><input type="radio" id="q2a0" name="q2" value="0"><label for="q2a0">git push</label></div>
+    <div><input type="radio" id="q2a1" name="q2" value="1"><label for="q2a1">git upload</label></div>
+    <div><input type="radio" id="q2a2" name="q2" value="2"><label for="q2a2">git send</label></div>
+    <div><input type="radio" id="q2a3" name="q2" value="3"><label for="q2a3">git commit</label></div>
+  </fieldset>
+  <fieldset aria-describedby="q3-desc">
+    <legend>Pregunta 3</legend>
+    <p id="q3-desc">¿Qué método de JavaScript guarda datos en el almacenamiento local del navegador?</p>
+    <div><input type="radio" id="q3a0" name="q3" value="0"><label for="q3a0">sessionStorage.setItem</label></div>
+    <div><input type="radio" id="q3a1" name="q3" value="1"><label for="q3a1">localStorage.setItem</label></div>
+    <div><input type="radio" id="q3a2" name="q3" value="2"><label for="q3a2">storage.save</label></div>
+    <div><input type="radio" id="q3a3" name="q3" value="3"><label for="q3a3">browser.store</label></div>
+  </fieldset>
+</form>
+<button id="finish" type="button">Calificar</button>
+<div id="result" aria-live="polite" style="margin-top:12px;"></div>
+<noscript><p>Activa JavaScript para calificar automáticamente.</p></noscript>
+<script>
+const ANSWERS = [1,0,1];
+const KEY = 'fs-00-quiz-score';
+const form = document.getElementById('quiz');
+const result = document.getElementById('result');
+const saved = localStorage.getItem(KEY);
+if (saved !== null) {
+  result.textContent = `Última puntuación: ${saved}%`;
+}
+document.getElementById('finish').addEventListener('click', () => {
+  let ok = 0;
+  ANSWERS.forEach((ans, i) => {
+    const sel = form.querySelector(`input[name="q${i+1}"]:checked`);
+    if (sel && +sel.value === ans) ok++;
+  });
+  const pct = Math.round(100 * ok / ANSWERS.length);
+  const cls = pct >= 80 ? 'ok' : 'bad';
+  result.innerHTML = `Puntaje: <b class="${cls}">${pct}%</b> (${ok}/${ANSWERS.length})`;
+  localStorage.setItem(KEY, pct);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add FS-00 multichoice quiz with JavaScript grading and minimal styles
- ensure accessible fallback markup with fieldset/legend and labels
- persist score via localStorage

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c375054b8c8325abb1ddf0e84ce6de