### PR TITLE
Update docs navigation for master plan

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,39 +1,49 @@
 # docs/_data/navigation.yml
-- title: Dev · DevOps · English Entry Level
+- title: Plan maestro
+  url: /#plan-maestro
+- title: Full-stack
   children:
-    - title: Full Stack
-      children:
-        - title: L0 · Scratch
-          url: /fullstack/00-scratch/
-        - title: L1 · Fundamentos
-          url: /fullstack/01-fundamentos/
-        - title: L2 · DOM
-          url: /fullstack/02-dom/
-        - title: L3 · Mid 1
-          url: /fullstack/03-mid1/
-        - title: L4 · Mid 2
-          url: /fullstack/04-mid2/
-    - title: DevOps
-      children:
-        - title: L0 · Scratch
-          url: /devops/l0-scratch/
-        - title: L1 · Starter
-          url: /devops/l1-starter/
-        - title: L2 · Builder
-          url: /devops/l2-builder/
-        - title: L3 · Advanced
-          url: /devops/l3-advanced/
-        - title: L4 · Pro
-          url: /devops/l4-pro/
-    - title: Quizzes (H5P)
-      children:
-        - title: FS-00
-          url: /h5p/fs-00-quiz/
-        - title: FS-01
-          url: /h5p/fs-01-quiz/
-        - title: FS-02
-          url: /h5p/fs-02-quiz/
-    - title: Mi primera web
-      url: /public/
-    - title: Material legacy
-      url: /legacy/
+    - title: N0 · Entry
+      url: /#full-stack-n0-entry
+    - title: N1 · Core
+      url: /#full-stack-n1-core
+    - title: N2 · Pro
+      url: /#full-stack-n2-pro
+    - title: N3 · Expert
+      url: /#full-stack-n3-expert
+- title: Integración de IA
+  children:
+    - title: N0 · Entry
+      url: /#integracion-ia-n0-entry
+    - title: N1 · Core
+      url: /#integracion-ia-n1-core
+    - title: N2 · Pro
+      url: /#integracion-ia-n2-pro
+    - title: N3 · Expert
+      url: /#integracion-ia-n3-expert
+- title: DevOps & Automatización
+  children:
+    - title: N0 · Entry
+      url: /#devops-n0-entry
+    - title: N1 · Core
+      url: /#devops-n1-core
+    - title: N2 · Pro
+      url: /#devops-n2-pro
+    - title: N3 · Expert
+      url: /#devops-n3-expert
+- title: Plantillas
+  url: /#plantillas
+- title: Runbooks / Postmortems
+  url: /#runbooks
+- title: Quizzes (H5P)
+  children:
+    - title: FS-00
+      url: /h5p/fs-00-quiz/
+    - title: FS-01
+      url: /h5p/fs-01-quiz/
+    - title: FS-02
+      url: /h5p/fs-02-quiz/
+- title: Mi primera web
+  url: /public/
+- title: Material histórico
+  url: /legacy/

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,29 +4,76 @@ nav_order: 0
 ---
 # DevSyllabus — Entry Level (Cohorte 01)
 
-**Accesos rápidos:** [Mi primera web](/public/) · [Week 0](/fullstack/00-setup/) · [L1 Frontend](/fullstack/01-frontend/) · [L2 DOM](/fullstack/02-dom/)
+Bienvenido al hub central de la cohorte. Aquí concentramos el plan maestro, los enlaces a cada especialidad y los artefactos operativos necesarios para avanzar nivel por nivel.
 
-> 📦 ¿Buscas documentación antigua? Reunimos los artefactos legacy en la sección [Material histórico](/legacy/).
+> 📦 ¿Buscas documentación antigua? Reunimos los artefactos legacy en la sección [Material histórico](#material-historico).
 
+## Plan maestro {: #plan-maestro }
+La ruta está organizada por especialidad y nivel. Cada bloque apunta a los contenidos oficiales y a los artefactos de apoyo que ya están disponibles en el repositorio.
 
-## Full-Stack
-
+### Full-stack {: #full-stack }
+#### N0 Entry {: #full-stack-n0-entry }
 - [Week 0: Setup & Your First Website](/fullstack/00-onboarding/)
-- [Week 1 — Setup & Your First Website ](/fullstack/01-setup/)
+- [Week 1 — Setup & Your First Website](/fullstack/01-setup/)
+
+#### N1 Core {: #full-stack-n1-core }
 - [Week 2: Fundamentals](/fullstack/02-fundamentals/)
 - [Week 3: DOM, eventos, accesibilidad y errores](/fullstack/03-dom/)
-- [Week 2: Scratch: publicar tu primera web](/fullstack/00-scratch/)
-- [Week 3: Frontend](/fullstack/01-frontend/)
-- [PLACEHOLDER — Full Stack](/fullstack/03-mid1/)
-- [PLACEHOLDER — Full Stack](/fullstack/04-mid2/)
-- [Full Stack](/fullstack/index/)
+- [01 — Frontend](/fullstack/05-frontend/)
 
+#### N2 Pro {: #full-stack-n2-pro }
+- [Mid 1 — Roadmap en construcción](/fullstack/06-mid1/)
 
-## DevOps
+#### N3 Expert {: #full-stack-n3-expert }
+- [Mid 2 — Roadmap en construcción](/fullstack/07-mid2/)
 
-- [DEVOPS · Título del nivel](/devops/l0-scratch/)
-- [DEVOPS · Título del nivel](/devops/l1-starter/)
-- [DEVOPS · Título del nivel](/devops/l2-builder/)
-- [DEVOPS · Título del nivel](/devops/l3-advanced/)
-- [DEVOPS · Título del nivel](/devops/l4-pro/)
+### Integración de IA {: #integracion-ia }
+#### N0 Entry {: #integracion-ia-n0-entry }
+- [AI Speaking Coach (beta)](/ai-speaking.html)
 
+#### N1 Core {: #integracion-ia-n1-core }
+- _Contenido en migración. La documentación final se publicará en este repositorio._
+
+#### N2 Pro {: #integracion-ia-n2-pro }
+- _Contenido en migración. La documentación final se publicará en este repositorio._
+
+#### N3 Expert {: #integracion-ia-n3-expert }
+- _Contenido en migración. La documentación final se publicará en este repositorio._
+
+### DevOps & Automatización {: #devops-automatizacion }
+#### N0 Entry {: #devops-n0-entry }
+- [Nivel L0 · Scratch](/devops/l0-scratch/)
+
+#### N1 Core {: #devops-n1-core }
+- [Nivel L1 · Starter](/devops/l1-starter/)
+
+#### N2 Pro {: #devops-n2-pro }
+- [Nivel L2 · Builder](/devops/l2-builder/)
+
+#### N3 Expert {: #devops-n3-expert }
+- [Nivel L3 · Advanced](/devops/l3-advanced/)
+
+## Plantillas listas para usar {: #plantillas }
+- [Docker Compose base](/saas-devops-course/templates/docker-compose.yml)
+- [CI pipeline (GitHub Actions)](/saas-devops-course/templates/github-workflows/ci.yml)
+- [Configuración de la API NestJS](/saas-devops-course/templates/apps-api/src/main.ts)
+- [Infraestructura Terraform base](/saas-devops-course/templates/terraform/main.tf)
+
+## Runbooks y postmortems {: #runbooks }
+- [Runbook · Base de datos fuera de servicio](/saas-devops-course/templates/runbooks/db-outage.md)
+- [Plantilla de postmortem](/saas-devops-course/templates/runbooks/postmortem-template.md)
+
+## Quizzes (H5P) {: #quizzes-h5p }
+- [FS-00](/h5p/fs-00-quiz/)
+- [FS-01](/h5p/fs-01-quiz/)
+- [FS-02](/h5p/fs-02-quiz/)
+
+## Mi primera web {: #mi-primera-web }
+El entorno público con los ejemplos y assets para desplegar la primera web.
+
+- [Ir a la carpeta pública](/public/)
+
+## Material histórico {: #material-historico }
+Los artefactos de cohorts anteriores siguen disponibles para consulta y descarga.
+
+- [Explorar el material histórico](/legacy/)


### PR DESCRIPTION
## Summary
- refactor the documentation navigation so Home points to the master plan, specialties expose N0–N3 levels, and new Plantillas/Runbooks links are available
- restructure the master plan landing page with anchored sections for each specialty plus quick access to templates, runbooks, quizzes, and legacy material

## Testing
- not run (docs changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d040d3bd4483259a03c69e2de0de2b