### PR TITLE
Actualizar referencias a material histórico

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -35,5 +35,5 @@
           url: /h5p/fs-02-quiz/
     - title: Mi primera web
       url: /public/
-    - title: Material legacy
+    - title: Material histórico
       url: /legacy/

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ nav_order: 0
 
 **Accesos rápidos:** [Mi primera web](/public/) · [Week 0](/fullstack/00-setup/) · [L1 Frontend](/fullstack/01-frontend/) · [L2 DOM](/fullstack/02-dom/)
 
-> 📦 ¿Buscas documentación antigua? Reunimos los artefactos legacy en la sección [Material histórico](/legacy/).
+> 📦 ¿Buscas documentación antigua? Reunimos el material histórico en la sección [Material histórico](/legacy/).
 
 
 ## Full-Stack

--- a/docs/legacy/index.md
+++ b/docs/legacy/index.md
@@ -3,9 +3,9 @@ title: Material histórico
 nav_order: 90
 ---
 
-# Material histórico y artefactos legacy
+# Material histórico
 
-Esta carpeta conserva guías y artefactos de cohorts anteriores. Todo el contenido se movió fuera de la raíz de la app para mantener limpio el código productivo, pero sigue estando disponible para consulta.
+Esta carpeta conserva guías y material histórico de cohorts anteriores. Todo el contenido se movió fuera de la raíz de la app para mantener limpio el código productivo, pero sigue estando disponible para consulta.
 
 ## Accesos rápidos
 
@@ -13,14 +13,14 @@ Esta carpeta conserva guías y artefactos de cohorts anteriores. Todo el conteni
 - [Assignments Fullstack](./assignments-fullstack/)
 - [Assignment 01 · Hello API](./assignment-01-hello-api/)
 
-## Cómo clonar o descargar solo el material legacy
+## Cómo clonar o descargar solo el material histórico
 
-Si necesitas trabajar únicamente con estos recursos históricos, puedes clonar este repositorio y copiar la carpeta `docs/legacy/`:
+Si necesitas trabajar únicamente con estos recursos históricos, puedes clonar este repositorio y copiar la carpeta `docs/legacy/` (material histórico):
 
 ```bash
 git clone <tu-fork-o-repo>
 cd devsillabus-entrylevel
-cp -R docs/legacy ~/legacy-devsyllabus
+cp -R docs/legacy ~/material-historico-devsyllabus
 ```
 
 También puedes utilizar `git sparse-checkout` para traer solo esta carpeta:
@@ -32,4 +32,4 @@ git sparse-checkout init --cone
 git sparse-checkout set docs/legacy
 ```
 
-> Consejo: si la organización decide mover el material legacy a un repositorio independiente en el futuro, este archivo debe actualizarse con la URL correspondiente.
+> Consejo: si la organización decide mover el material histórico a un repositorio independiente en el futuro, este archivo debe actualizarse con la URL correspondiente.


### PR DESCRIPTION
## Summary
- reemplazar referencias textuales a "legacy" por "material histórico" en la página principal y navegación
- actualizar la guía principal de Material histórico para reflejar la nomenclatura definitiva, incluyendo instrucciones de copia y clonación

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d040e2092c83258d643c245040223f