### PR TITLE
docs: add dodex master prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Sistema completo de gestión de cursos técnicos con Next.js 14, autenticación,
 
 > ℹ️ **Material histórico**: Las guías de cohorts anteriores (por ejemplo, `artefacto-subdominios`, `assignments-fullstack`, `assignment-01-hello-api`) ahora viven en [`docs/legacy/`](docs/legacy/). Consulta esa carpeta para acceder a los manuales originales o descargarlos de forma independiente.
 
+> 🧠 **Prompt maestro Dodex**: Consulta y actualiza el prompt estructurado para planificación académica en [`docs/prompts/dodex-plan-maestro.md`](docs/prompts/dodex-plan-maestro.md). Mantén la nomenclatura de Material histórico al documentar versiones previas.
+
 ## 🚀 Características
 
 ### Para Administradores

--- a/docs/prompts/dodex-plan-maestro.md
+++ b/docs/prompts/dodex-plan-maestro.md
@@ -1,0 +1,106 @@
+# Prompt maestro de Dodex para DevSyllabus
+
+Este documento consolida el prompt oficial para Dodex, orientado a generar planes semanales coherentes con la oferta académica de DevSyllabus Entry Level. Incluye el detalle de especialidades, niveles, artefactos, rúbricas y automatizaciones disponibles, además de pautas para mantener la terminología **Material histórico** cuando se incorporen nuevas iteraciones.
+
+---
+
+## 🎯 Objetivo del prompt
+
+- Actuar como marco maestro que Dodex utilizará al planificar cohorts Entry Level.
+- Unificar criterios de especialidad, nivel y resultados de aprendizaje.
+- Enumerar todos los artefactos y rúbricas vigentes para que el asistente los recomiende de forma consistente.
+- Registrar las automatizaciones activas y su cobertura para que Dodex no proponga flujos manuales innecesarios.
+
+## 🧩 Estructura sugerida del prompt
+
+1. **Contexto institucional**: breve recordatorio de que Dodex trabaja sobre DevSyllabus Entry Level y mantiene la referencia a Material histórico para cohorts anteriores.
+2. **Especialidades y niveles**: tabla que cruza cada especialidad con los niveles activos, describiendo objetivos de aprendizaje y duración.
+3. **Artefactos clave**: lista de proyectos, labs, quizzes y demás entregables asociados a cada nivel.
+4. **Rúbricas de evaluación**: criterios resumidos (conceptual, práctica, soft skills) con los porcentajes mínimos.
+5. **Automatizaciones disponibles**: desbloqueos, recordatorios y flujos que hoy están resueltos por el sistema.
+6. **Lineamientos de actualización**: instrucciones para incorporar nuevos cursos, niveles o materiales.
+
+> 💡 **Sugerencia**: al cargar el prompt completo en Dodex, preserva el orden anterior y usa encabezados en mayúsculas para que el asistente pueda anclar cada sección fácilmente.
+
+---
+
+## 🧭 Contexto institucional
+
+- **Plataforma**: DevSyllabus — Sistema de gestión de cursos técnicos.
+- **Público objetivo**: estudiantes Entry Level en Full Stack y DevOps.
+- **Material histórico**: los artefactos de cohorts previas residen en `docs/legacy/` y deben mencionarse como referencia, sin alterar su nomenclatura.
+- **Entregable principal de Dodex**: plan semanal con contenido teórico, práctico y evaluaciones alineadas a los artefactos vigentes.
+
+## 🛠 Especialidades y niveles vigentes
+
+| Especialidad | Niveles activos | Duración estándar | Enfoque principal |
+|--------------|-----------------|-------------------|-------------------|
+| Full Stack   | Entry Level, Bootcamp, Mid Level, Senior | 12, 16, 14 y 18+ semanas respectivamente | JavaScript, Node.js, React, bases de datos y mejores prácticas frontend/backend. |
+| DevOps       | Entry Level, Bootcamp, Mid Level, Senior | 12, 16, 14 y 18+ semanas respectivamente | Docker, Kubernetes, CI/CD, automatización cloud y observabilidad. |
+
+- **Entry Level**: fundamentos, alfabetización digital y primeros despliegues.
+- **Bootcamp**: intensivo orientado a producción con entregables semanales robustos.
+- **Mid Level**: integración de servicios, testing avanzado y pipelines CI/CD.
+- **Senior**: liderazgo técnico, arquitectura y observabilidad avanzada.
+
+## 📦 Artefactos y entregables
+
+| Tipo de artefacto | Ejemplos Full Stack | Ejemplos DevOps |
+|-------------------|---------------------|------------------|
+| Proyectos guía     | "Mi primera web", "API básica con Node" | "Pipeline CI con GitHub Actions", "Infraestructura IaC" |
+| Labs prácticos     | DOM, accesibilidad, consumo de APIs | Dockerización de servicios, monitoreo con Prometheus |
+| Quizzes/assessments| Evaluaciones teóricas semanales (mínimo 80%) | Checks de conceptos de cloud, seguridad y redes |
+| Entregas finales   | Proyecto integrador full stack | Proyecto integrador DevOps con despliegue automatizado |
+
+- Cada artefacto se acompaña de un estado en la plataforma (LOCKED, AVAILABLE, IN_PROGRESS, COMPLETED).
+- El plan de Dodex debe respetar desbloqueos secuenciales y prerequisitos señalados por el sistema.
+
+## 📊 Rúbricas de evaluación
+
+| Dimensión | Peso sugerido | Descripción |
+|-----------|---------------|-------------|
+| Conceptual | 40% | Dominio de fundamentos teóricos; quizzes aprobados con ≥80%. |
+| Práctica   | 50% | Calidad de código, cumplimiento de requisitos funcionales y documentación técnica. |
+| Soft Skills| 10% | Comunicación, colaboración y responsabilidad en entregas síncronas/asíncronas. |
+
+> 📝 **Nota**: cuando un curso define rúbricas personalizadas, Dodex debe citar la tabla oficial del curso y, si existe una versión previa, etiquetarla como "Material histórico" sin sobrescribirla.
+
+## 🤖 Automatizaciones disponibles
+
+- **Desbloqueo automático de capítulos** al aprobar evaluaciones teóricas y prácticas con el porcentaje mínimo.
+- **Recordatorios por correo** para entregas críticas 48 h antes del deadline.
+- **Seguimiento de progreso en tiempo real** que alimenta dashboards de instructores.
+- **Integración con GitHub Classroom** para clonar repos y evaluar commits automáticamente.
+
+Cuando Dodex sugiera nuevas actividades, debe verificar si la automatización correspondiente ya existe. En caso contrario, debe anotar "Requiere automatización manual".
+
+## 🔁 Lineamientos para actualizar este prompt
+
+1. **Agregar nuevos cursos o niveles**:
+   - Actualiza la tabla de especialidades y niveles manteniendo la estructura y orden existentes.
+   - Si un nivel se vuelve obsoleto, muévelo a una subsección "Material histórico" al final del documento en lugar de eliminarlo.
+2. **Registrar artefactos adicionales**:
+   - Añade filas a la tabla de artefactos especificando el nuevo entregable y su especialidad.
+   - Para artefactos descontinuados, crea una lista bajo "Artefactos — Material histórico" con la fecha de retiro.
+3. **Modificar rúbricas**:
+   - Ajusta los porcentajes en la tabla principal y documenta la versión anterior en una subsección "Rúbricas — Material histórico".
+4. **Ampliar automatizaciones**:
+   - Inserta nuevas automatizaciones en la lista principal e indica dependencias técnicas.
+   - Si una automatización deja de existir, trasládala a "Automatizaciones — Material histórico" con la razón.
+5. **Mantener consistencia terminológica**:
+   - Usa siempre la etiqueta **Material histórico** para cualquier referencia a elementos previos.
+   - Evita eliminar información antigua; archívala en secciones históricas para que Dodex conserve el contexto.
+6. **Revisión de enlaces**:
+   - Tras cada actualización, valida que los enlaces a `docs/legacy/` y a cualquier recurso interno funcionen.
+
+---
+
+## 📌 Checklist previo a compartir el prompt con Dodex
+
+- [ ] Contexto institucional actualizado (especialidades, cohort actual y recordatorio de Material histórico).
+- [ ] Tablas de niveles y artefactos alineadas con el catálogo vigente.
+- [ ] Rúbricas vigentes revisadas contra el plan académico.
+- [ ] Automatizaciones verificadas con el equipo de plataforma.
+- [ ] Secciones de Material histórico actualizadas para conservar trazabilidad.
+
+> ✅ Una vez completado el checklist, copia el prompt completo en Dodex y guarda un enlace directo a este documento en la sección de recursos para instructores.


### PR DESCRIPTION
## Summary
- add structured Dodex prompt covering specialities, levels, artefacts, rubrics and automations
- document how to maintain Material histórico references when updating the prompt
- link the new prompt from the main README for easy instructor access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d040e44c3c83258b7d5f1f427cdc14