### PR TITLE
Add DevOps beginner theory link to navigation

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -18,6 +18,8 @@
       children:
         - title: N0 · Entry · Docker 101
           url: /devops/n0-entry/
+        - title: DevOps Beginner · Teoría
+          url: /devops/devops-beginner-theory/
         - title: N1 · Core · Monitorización
           url: /devops/n1-core/
         - title: N2 · Pro · Automatizaciones n8n


### PR DESCRIPTION
## Summary
- add DevOps Beginner · Teoría entry to the DevOps navigation section

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbe892073483258f3bc13e66433fbf