### PR TITLE
Add DevOps automation links to master plan

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,13 @@ Bienvenido al hub central de la cohorte. Aquí concentramos el plan maestro, los
 
 
 ### DevOps & Automatización
+
+- [Guía — Fundamentos DevOps para principiantes](/devops/devops-beginner-theory/)
+- [N0 · Entry — Docker 101](/devops/n0-entry/)
+- [N1 · Core — Monitorización y Observabilidad](/devops/n1-core/)
+- [N2 · Pro — Automatizaciones con n8n](/devops/n2-pro/)
+- [N3 · Expert — Incident Response](/devops/n3-expert/)
+
 ## AI Automation
 
 - [N0 · Entry — OpenAI API Foundations](/ai/n0-entry/)


### PR DESCRIPTION
## Summary
- add DevOps guide and level routes to the master plan index for consistency with other specialties

## Testing
- not run (docs change only)

------
https://chatgpt.com/codex/tasks/task_e_68dbe89212308325971b3d7e1516cee9